### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,5 +1,8 @@
 name: Deploy App to VPS
 
+permissions:
+  contents: read
+
 on:
   push:
     tags:


### PR DESCRIPTION
Potential fix for [https://github.com/burtek/dtrw-app-helloworld/security/code-scanning/1](https://github.com/burtek/dtrw-app-helloworld/security/code-scanning/1)

To fix the issue, add an explicit `permissions` block specifying the least required access for the workflow. The workflow does not perform any actions that require write access to repository contents or other resources; it primarily checks out code, installs dependencies, builds, runs tests, and deploys code via SSH/SCP to a VPS. Therefore, the only required permission is likely `contents: read` (needed for `actions/checkout`). This block should be added at the workflow level (top-level, above `jobs:`), so it applies to all jobs. No changes to the functionality of existing steps are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
